### PR TITLE
fix: Remove currency symbol from 'Last price' display in POS

### DIFF
--- a/resources/pos/src/frontend/components/product/Product.js
+++ b/resources/pos/src/frontend/components/product/Product.js
@@ -126,6 +126,18 @@ const Product = (props) => {
         );
     //Cart Item Array
     const loadAllProduct = (product, index) => {
+        let displayValue = "";
+        if (customerId && lastSalePrices) {
+            const priceKey = `${product.id}_${customerId}`;
+            if (lastSalePrices[priceKey] === null) {
+                displayValue = "-";
+            } else if (typeof lastSalePrices[priceKey] === 'number') {
+                displayValue = getFormattedMessage("pos.last-price.label") + " " + Number(lastSalePrices[priceKey]).toFixed(2);
+            } else if (lastSalePrices[priceKey] === undefined) {
+                displayValue = "..."; // Loading indicator
+            }
+        }
+
         const findDifferentWords = (str1, str2) => {
             const words1 = str1.split("_");
             const words2 = str2.split("_");
@@ -184,15 +196,10 @@ const Product = (props) => {
                                 {product?.attributes?.product_unit_name?.name}
                             </Badge>
                         </p>
-                        <p className="m-0 item-badge">
-                            {customerId && lastSalePrices && lastSalePrices[`${product.id}_${customerId}`] !== undefined && (
+                        <p className="m-0 item-badge product-last-customer-price">
+                            {customerId && (
                                 <span className="d-block fs-small mb-1">
-                                    {lastSalePrices[`${product.id}_${customerId}`] === null
-                                        ? <span className="text-muted">-</span>
-                                        : <span className="text-success">
-                                            {getFormattedMessage("pos.last-price.label")}: {currencySymbolHandling(allConfigData, settings.attributes?.currency_symbol, lastSalePrices[`${product.id}_${customerId}`])}
-                                          </span>
-                                    }
+                                    {displayValue}
                                 </span>
                             )}
                             <Badge


### PR DESCRIPTION
This commit updates the 'Last customer price' feature in the POS product selection area to display the numerical value of the last price without the currency symbol, as per your request.

- Modified `Product.js` to format the `lastSalePrices[priceKey]` using `toFixed(2)` directly, instead of `currencySymbolHandling`, for the 'Last price: X.XX' display.
- The main product price display continues to use `currencySymbolHandling` and will show the currency symbol.
- Other display conditions for 'Last price' (showing '-', '...', or being hidden if no customer is selected) remain unchanged.